### PR TITLE
Prevent duplicate access objects

### DIFF
--- a/data-management/neo4j-service.js
+++ b/data-management/neo4j-service.js
@@ -216,7 +216,7 @@ async function requestArmAccess(listParams, userInfo) {
             `
             MATCH (user:User) 
             WHERE user.email='${userInfo.email}' and user.IDP ='${userInfo.idp}'
-            MATCH (user)<-[:of_user]-(access:Access)-[:of_arm]->(arm)
+            OPTIONAL MATCH (user)<-[:of_user]-(access:Access)-[:of_arm]->(arm)
             WHERE arm.id=$armID AND access.accessStatus IN ['${REJECTED}', '${REVOKED}']
             DETACH DELETE access
             WITH user


### PR DESCRIPTION
- If a user submits a DAR for an arm that has previously been rejected or revoked, then the previous access object will be deleted before creating the new one